### PR TITLE
Django-q implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 2. python manage.py migrate
 3. python manage.py runscript generate_data
 4. python manage.py runserver
+5. python manage.py qcluster
 
 Site
 http//:localhost:8000

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 1. python manage.py makemigrations
 2. python manage.py migrate
 3. python manage.py runscript generate_data
-4. python manage.py runserver
-5. python manage.py qcluster
+4. python manage.py runscript generate_jobs
+5. python manage.py runserver
+6. python manage.py qcluster
 
 Site
 http//:localhost:8000

--- a/noq_django/backend/models.py
+++ b/noq_django/backend/models.py
@@ -54,6 +54,9 @@ class UserDetails(models.Model):
         Region, on_delete=models.CASCADE, null=False, blank=False
     )
 
+    #Datum för senaste uppdateringen av användarodellen, för att avgöra om användaren är aktiv
+    last_edit = models.DateField(verbose_name="Senaste Aktivitet")
+
     class Meta:
         db_table = "users"
     
@@ -61,6 +64,14 @@ class UserDetails(models.Model):
 
     def name(self) -> str:
         return f"{self.first_name} {self.last_name}"
+
+    def save(self, *args, **kwargs):
+        if 'fake_data' in kwargs:  #Om data är genererat av script använd istället för time.now
+            self.last_edit = kwargs.pop('fake_data')
+            super(UserDetails, self).save(*args, **kwargs)
+        else:   
+            self.last_edit = datetime.now()
+            super(UserDetails, self).save(*args, **kwargs)
 
     def __str__(self) -> str:
         # rsrv = ProductBooking.objects.filter(user=self).order_by("-start_date").first()

--- a/noq_django/backend/scripts/generate_data.py
+++ b/noq_django/backend/scripts/generate_data.py
@@ -119,6 +119,9 @@ def add_users(nbr: int):
         ).values():
             continue
 
+        last_edit = datetime.now() - timedelta(days=random.randint(0, 31))
+
+
         user = UserDetails(
             first_name=first_name,
             last_name=last_name,
@@ -130,7 +133,7 @@ def add_users(nbr: int):
             street=faker.street_address(),
             city=stad,
         )
-        user.save()
+        user.save(fake_data=last_edit)
 
 
 def add_product_bookings(nbr: int, days_ahead: int = 3, verbose: bool = False):

--- a/noq_django/backend/scripts/generate_jobs.py
+++ b/noq_django/backend/scripts/generate_jobs.py
@@ -1,0 +1,22 @@
+from datetime import datetime
+from django_q.models import Schedule
+
+def delete_entries(): #rensa tidigare schemaläggningar från databasen om det finns några
+    jobs = Schedule.objects.all()
+    if len(jobs) != 0:
+        for i in jobs:
+            i.delete()
+    
+
+def create_jobs(): #lägg till bakrundsprocesser som skall skapas här
+    Schedule.objects.create(
+    name='Remove Inactive Users',
+    func='backend.tasks.remove_inactive',
+    schedule_type=Schedule.DAILY,
+    repeats=-1,
+    next_run=datetime.now().replace(hour=0, minute=0, second=0, microsecond=0),
+    )
+
+def run():
+    delete_entries()
+    create_jobs()

--- a/noq_django/backend/scripts/remove_inactive.py
+++ b/noq_django/backend/scripts/remove_inactive.py
@@ -1,0 +1,16 @@
+from datetime import datetime, timedelta
+from icecream import ic
+
+from backend.models import UserDetails
+
+#Kolla om användaren har varit aktiv inom senaste X dagarna
+def list_inactive():
+    days_old = datetime.now() - timedelta(days=30) #Antal dagar innan flaggad för borttagning
+    inactive_users = UserDetails.objects.filter(last_edit__lte=days_old)
+    return inactive_users
+
+def run():
+    inactive_users = list_inactive()
+    count = len(inactive_users)
+    inactive_users.delete()
+    print(f"Successfully removed {count}")

--- a/noq_django/backend/tasks.py
+++ b/noq_django/backend/tasks.py
@@ -3,6 +3,9 @@ from icecream import ic
 
 from backend.models import UserDetails
 
+#Lägg i denna fil till funktioner som skall köras som bakrundsprocesser genom django-q
+#skapa sedan processen genom adminsidan /admin/django_q/schedule/ eller lägg till dem i generate_jobs.py scriptet
+
 #Kolla om användaren har varit aktiv inom senaste X dagarna
 def remove_inactive():
     days_old = datetime.now() - timedelta(days=30) #Antal dagar innan flaggad för borttagning

--- a/noq_django/backend/tasks.py
+++ b/noq_django/backend/tasks.py
@@ -4,13 +4,9 @@ from icecream import ic
 from backend.models import UserDetails
 
 #Kolla om användaren har varit aktiv inom senaste X dagarna
-def list_inactive():
+def remove_inactive():
     days_old = datetime.now() - timedelta(days=30) #Antal dagar innan flaggad för borttagning
     inactive_users = UserDetails.objects.filter(last_edit__lte=days_old)
-    return inactive_users
-
-def run():
-    inactive_users = list_inactive()
     count = len(inactive_users)
     inactive_users.delete()
     print(f"Successfully removed {count}")

--- a/noq_django/noq_django/settings.py
+++ b/noq_django/noq_django/settings.py
@@ -66,6 +66,7 @@ MIDDLEWARE = [
 Q_CLUSTER = {
     "name": "noq_django",
     "orm": "default",
+    "max_attempts": 2,
 }
 
 ROOT_URLCONF = "noq_django.urls"

--- a/noq_django/noq_django/settings.py
+++ b/noq_django/noq_django/settings.py
@@ -49,7 +49,7 @@ INSTALLED_APPS = [
     "corsheaders",
     "crispy_bootstrap4",
     "django_tables2",
-     
+    "django_q",
 ]
 
 MIDDLEWARE = [
@@ -62,6 +62,11 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
 ]
+
+Q_CLUSTER = {
+    "name": "noq_django",
+    "orm": "default",
+}
 
 ROOT_URLCONF = "noq_django.urls"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ pygments==2.17.2
 six==1.16.0
 sqlparse==0.4.4
 typing-extensions==4.9.0
+django-q==1.3.9


### PR DESCRIPTION
Implementation av [django-q](https://github.com/Koed00/django-q) relaterat till issue #6 

Det finns en meny för att lägga till bakrundsprocesser genom adminsidan
![image](https://github.com/noQ-sweden/noq_backend_python/assets/162132004/f6bd4826-9bb3-45e1-baa1-2c8e52c51d5b)

Alternativt finns det även ett script (generate_jobs.py) för att initiera bakrundsprocesser (samlas i tasks.py) samt rensa gamla schemaläggningar för att undvika dubletter