### PR TITLE
Adds bulk accept bookings api for caseworker

### DIFF
--- a/noq_django/rest_api/api/api_schemas.py
+++ b/noq_django/rest_api/api/api_schemas.py
@@ -156,6 +156,11 @@ class BookingPostSchema(Schema):
     end_date: date
     product_id: int
 
+
+class BookingUpdateSchema(Schema):
+    booking_id: int
+
+
 class AvailableSchema(Schema):
     """
     Available för att kunna se om en Product har tillgängliga platser

--- a/noq_django/rest_api/api/caseworker_api.py
+++ b/noq_django/rest_api/api/caseworker_api.py
@@ -59,8 +59,8 @@ def get_pending_bookings(request, limiter: Optional[int] = None):  # Limiter exa
     return bookings
 
 
-@router.patch("/bookings/bulk/accept", response={200: dict, 400: dict}, tags=["caseworker-manage-requests"])
-def bulk_appoint_pending_booking(request, booking_ids: list[BookingUpdateSchema]):
+@router.patch("/bookings/batch/accept", response={200: dict, 400: dict}, tags=["caseworker-manage-requests"])
+def batch_appoint_pending_booking(request, booking_ids: list[BookingUpdateSchema]):
     hosts = Host.objects.filter(users=request.user)
     # Use a transaction to ensure all or nothing behavior
     with transaction.atomic():
@@ -77,7 +77,7 @@ def bulk_appoint_pending_booking(request, booking_ids: list[BookingUpdateSchema]
         if errors:
             return 400, {'message': 'Some updates failed', 'errors': errors}
 
-    return 200, {'message': 'Bulk update successful'}
+    return 200, {'message': 'Batch update successful'}
 
 
 @router.patch("/bookings/{booking_id}/accept", response=BookingSchema, tags=["caseworker-manage-requests"])

--- a/noq_django/rest_api/api/caseworker_api.py
+++ b/noq_django/rest_api/api/caseworker_api.py
@@ -1,6 +1,7 @@
 from django.db.models import Q
 from ninja import NinjaAPI, Schema, ModelSchema, Router
 from ninja.errors import HttpError
+from django.db import transaction
 from datetime import datetime, timedelta
 
 from backend.models import (
@@ -32,6 +33,7 @@ from .api_schemas import (
     AvailablePerDateSchema,
     InvoiceCreateSchema,
     InvoiceResponseSchema,
+    BookingUpdateSchema,
 )
 
 from backend.auth import group_auth
@@ -55,6 +57,27 @@ def get_pending_bookings(request, limiter: Optional[int] = None):  # Limiter exa
         return bookings[:limiter]
 
     return bookings
+
+
+@router.patch("/bookings/bulk/accept", response={200: dict, 400: dict}, tags=["caseworker-manage-requests"])
+def bulk_appoint_pending_booking(request, booking_ids: list[BookingUpdateSchema]):
+    hosts = Host.objects.filter(users=request.user)
+    # Use a transaction to ensure all or nothing behavior
+    with transaction.atomic():
+        errors = []
+        for item in booking_ids:
+            booking_id = item.booking_id
+            booking = get_object_or_404(Booking, id=booking_id, product__host__in=hosts, status__description='pending')
+            try:
+                booking.status = BookingStatus.objects.get(description='accepted')
+                booking.save()
+            except Exception as e:
+                # Collect errors for any failed updates
+                errors.append({'booking': item.booking_id, 'error': str(e)})
+        if errors:
+            return 400, {'message': 'Some updates failed', 'errors': errors}
+
+    return 200, {'message': 'Bulk update successful'}
 
 
 @router.patch("/bookings/{booking_id}/accept", response=BookingSchema, tags=["caseworker-manage-requests"])

--- a/noq_django/rest_api/api/host_api.py
+++ b/noq_django/rest_api/api/host_api.py
@@ -165,8 +165,8 @@ def detailed_pending_booking(request, booking_id: int):
 
     return booking
 
-@router.patch("/pending/bulk/accept", response={200: dict, 400: dict}, tags=["caseworker-manage-requests"])
-def bulk_appoint_pending_booking(request, booking_ids: list[BookingUpdateSchema]):
+@router.patch("/pending/batch/accept", response={200: dict, 400: dict}, tags=["caseworker-manage-requests"])
+def batch_appoint_pending_booking(request, booking_ids: list[BookingUpdateSchema]):
     hosts = Host.objects.filter(users=request.user)
     # Use a transaction to ensure all or nothing behavior
     with transaction.atomic():
@@ -183,7 +183,7 @@ def bulk_appoint_pending_booking(request, booking_ids: list[BookingUpdateSchema]
         if errors:
             return 400, {'message': 'Some updates failed', 'errors': errors}
 
-    return 200, {'message': 'Bulk update successful'}
+    return 200, {'message': 'Batch update successful'}
 
 
 @router.patch("/pending/{booking_id}/appoint", response=BookingSchema, tags=["host-manage-requests"])

--- a/noq_django/rest_api/api/host_api.py
+++ b/noq_django/rest_api/api/host_api.py
@@ -2,6 +2,7 @@ from django.db.models import Q
 from ninja import NinjaAPI, Schema, ModelSchema, Router
 from ninja.errors import HttpError
 from datetime import datetime, timedelta
+from django.db import transaction
 
 from backend.models import (
     Client,
@@ -32,6 +33,7 @@ from .api_schemas import (
     AvailablePerDateSchema,
     InvoiceCreateSchema,
     InvoiceResponseSchema,
+    BookingUpdateSchema,
 )
 
 from backend.auth import group_auth
@@ -162,6 +164,26 @@ def detailed_pending_booking(request, booking_id: int):
     booking = get_object_or_404(Booking, id=booking_id, product__host=host, status__description='pending')
 
     return booking
+
+@router.patch("/pending/bulk/accept", response={200: dict, 400: dict}, tags=["caseworker-manage-requests"])
+def bulk_appoint_pending_booking(request, booking_ids: list[BookingUpdateSchema]):
+    hosts = Host.objects.filter(users=request.user)
+    # Use a transaction to ensure all or nothing behavior
+    with transaction.atomic():
+        errors = []
+        for item in booking_ids:
+            booking_id = item.booking_id
+            booking = get_object_or_404(Booking, id=booking_id, product__host__in=hosts, status__description='pending')
+            try:
+                booking.status = BookingStatus.objects.get(description='accepted')
+                booking.save()
+            except Exception as e:
+                # Collect errors for any failed updates
+                errors.append({'booking': item.booking_id, 'error': str(e)})
+        if errors:
+            return 400, {'message': 'Some updates failed', 'errors': errors}
+
+    return 200, {'message': 'Bulk update successful'}
 
 
 @router.patch("/pending/{booking_id}/appoint", response=BookingSchema, tags=["host-manage-requests"])

--- a/noq_django/rest_api/api/host_api.py
+++ b/noq_django/rest_api/api/host_api.py
@@ -165,7 +165,7 @@ def detailed_pending_booking(request, booking_id: int):
 
     return booking
 
-@router.patch("/pending/batch/accept", response={200: dict, 400: dict}, tags=["caseworker-manage-requests"])
+@router.patch("/pending/batch/accept", response={200: dict, 400: dict}, tags=["host-manage-requests"])
 def batch_appoint_pending_booking(request, booking_ids: list[BookingUpdateSchema]):
     hosts = Host.objects.filter(users=request.user)
     # Use a transaction to ensure all or nothing behavior

--- a/noq_django/rest_api/api/test/test_caseworker_handle_booking_api.py
+++ b/noq_django/rest_api/api/test/test_caseworker_handle_booking_api.py
@@ -169,7 +169,7 @@ class TestCaseworkerHandleBookingApi(TestCase):
         self.assertEqual(len(parsed_response), 2)
 
 
-    def test_bulk_accept_bookings(self):
+    def test_batch_accept_bookings(self):
         # Connect host_user and host
         host = Host.objects.get(name="Host 1")
         caseworker_user = User.objects.get(username="user.caseworker@test.nu")
@@ -181,9 +181,9 @@ class TestCaseworkerHandleBookingApi(TestCase):
         pending_count = Booking.objects.filter(status=State.PENDING).count()
         self.assertEqual(pending_count, 4)
 
-        # Accept 4 booking in a bulk, there should be 0 pending bookings left
+        # Accept 4 booking in a batch, there should be 0 pending bookings left
         pending_bookings = Booking.objects.filter(status=State.PENDING).all()
-        url = "/api/caseworker/bookings/bulk/accept"
+        url = "/api/caseworker/bookings/batch/accept"
         payload = [
             {'booking_id': 1},
             {'booking_id': 2},

--- a/noq_django/rest_api/api/test/test_host_handle_booking_api.py
+++ b/noq_django/rest_api/api/test/test_host_handle_booking_api.py
@@ -122,7 +122,7 @@ class TestHostHandleBookingApi(TestCase):
                 booking.save()
 
 
-    def test_bulk_accept_bookings(self):
+    def test_batch_accept_bookings(self):
         # Connect host_user and host
         host = Host.objects.get(name="Host 1")
         host_user = User.objects.get(username="user.host@test.nu")
@@ -134,9 +134,9 @@ class TestHostHandleBookingApi(TestCase):
         pending_count = Booking.objects.filter(status=State.PENDING).count()
         self.assertEqual(pending_count, 4)
 
-        # Accept 4 booking in a bulk, there should be 0 pending bookings left
+        # Accept 4 booking in a batch, there should be 0 pending bookings left
         pending_bookings = Booking.objects.filter(status=State.PENDING).all()
-        url = "/api/host/pending/bulk/accept"
+        url = "/api/host/pending/batch/accept"
         payload = [
             {'booking_id': 1},
             {'booking_id': 2},

--- a/noq_django/rest_api/api/test/test_host_handle_booking_api.py
+++ b/noq_django/rest_api/api/test/test_host_handle_booking_api.py
@@ -1,0 +1,162 @@
+import sys
+sys.path.append("....backend") # Adds folder where backend is to python modules path.
+import json
+from datetime import datetime, timedelta
+from django.test import TestCase
+from django.contrib.auth.models import User, Group
+from backend.models import (
+    Host, Client, Product, Region, Booking, State, BookingStatus, Available
+)
+from django.test import Client as TestClient
+from ..host_api import router
+
+class TestHostHandleBookingApi(TestCase):
+    host_user = None
+    host_name = "user.host@test.nu"
+    user_name_one = "user.user1@test.nu"
+    user_name_two = "user.user2@test.nu"
+    user_name_three = "user.user3@test.nu"
+    user_name_four = "user.user4@test.nu"
+    password = "VeryBadPassword!"
+
+    def create_user(self, username, group):
+        user = User.objects.create_user(username=username, password=self.password)
+        group_obj, created = Group.objects.get_or_create(name=group)
+        user.groups.add(group_obj)
+
+    def host_login(self):
+        # Create host user and client users for the test
+        if User.objects.filter(username=self.host_name).first() == None:
+            host_user = self.create_user(self.host_name, "host")
+            client_user_one = self.create_user(self.user_name_one, "user")
+            client_user_two = self.create_user(self.user_name_two, "user")
+            client_user_three = self.create_user(self.user_name_three, "user")
+            client_user_four = self.create_user(self.user_name_four, "user")
+
+        # Login the host
+        self.client = TestClient(router)
+        self.client.login(username=self.host_name, password=self.password)
+        print(self.client)
+
+
+    def delete_users(self):
+        # Delete the host_user created for the tests
+        users = User.objects.all().delete()
+
+
+    def delete_products(self):
+        # Delete all products created for the tests
+        Product.objects.all().delete()
+        Available.objects.all().delete()
+        Host.objects.all().delete()
+        Region.objects.all().delete()
+
+
+    def setUp(self):
+        # log in host user for the tests
+        self.host_login()
+
+        # Create products that can be used during the tests
+        if Product.objects.filter(id=1).first() == None:
+            region = Region.objects.create(name="Malmö")
+            hostA = Host.objects.create(name="Host 1", street="", postcode="", city="Malmö", region_id=region.id)
+            productA = Product.objects.create(name="room", total_places=5, host_id=hostA.id, type="room")
+
+        # Create clients
+        for i in range(1, 5):
+            client = Client.objects.create(
+                first_name="John" + str(i),
+                last_name="Doe",
+                gender="M",
+                street="123 Main St",
+                postcode="12345",
+                city="New York",
+                country="USA",
+                phone="123-456-7890",
+                email="john.doe@example.com",
+                unokod="ABC123",
+                day_of_birth=datetime.now().date() + timedelta(weeks=-1500),
+                personnr_lastnr="1234",
+                region=region,
+                requirements=None,
+                last_edit=datetime.now().date(),
+                user=User.objects.get(id=i),
+            )
+
+        statuses = [
+            {"id": State.PENDING, "description": "pending"},
+            {"id": State.DECLINED, "description": "declined"},
+            {"id": State.ACCEPTED, "description": "accepted"},
+            {"id": State.CHECKED_IN, "description": "checked_in"},
+            {"id": State.IN_QUEUE, "description": "in_queue"},
+            {"id": State.RESERVED, "description": "reserved"},
+            {"id": State.CONFIRMED, "description": "confirmed"},
+        ]
+
+        for status in statuses:
+            if not BookingStatus.objects.filter(id=status["id"]).exists():
+                booking_status = BookingStatus.objects.create(
+                    id=status["id"], description=status["description"]
+                )
+                booking_status.save()
+
+        # Create pending bookings
+        # 1 product x 4 guests = 4 bookings
+        host = Host.objects.get(name="Host 1")
+        host_products = Product.objects.filter(host=host)
+        clients = Client.objects.all()
+        start_date = datetime.now()
+        end_date = start_date + timedelta(days=1)
+
+        for product in host_products:
+            for guest in clients:
+                booking = Booking(
+                    start_date=start_date,
+                    end_date=end_date,
+                    product=product,
+                    user=guest,
+                    status=BookingStatus.objects.get(
+                        id=State.PENDING
+                    )
+                )
+                booking.save()
+
+
+    def test_bulk_accept_bookings(self):
+        # Connect host_user and host
+        host = Host.objects.get(name="Host 1")
+        host_user = User.objects.get(username="user.host@test.nu")
+        host.users.add(host_user)
+        host.save()
+
+        # There should be 4 pending bookings to start with
+        bookings = Booking.objects.filter(status=State.PENDING).all()
+        pending_count = Booking.objects.filter(status=State.PENDING).count()
+        self.assertEqual(pending_count, 4)
+
+        # Accept 4 booking in a bulk, there should be 0 pending bookings left
+        pending_bookings = Booking.objects.filter(status=State.PENDING).all()
+        url = "/api/host/pending/bulk/accept"
+        payload = [
+            {'booking_id': 1},
+            {'booking_id': 2},
+            {'booking_id': 3},
+            {'booking_id': 4},
+        ]
+
+        response = self.client.patch(url, json.dumps(payload), format='json')
+        self.assertEqual(response.status_code, 200)
+        pending_count = Booking.objects.filter(status=State.PENDING).count()
+        self.assertEqual(pending_count, 0)
+
+        # We should get 0 pending bookings via rest api
+        response = self.client.get("/api/host/pending")
+        self.assertEqual(response.status_code, 200)
+        parsed_response = json.loads(response.content)
+        self.assertEqual(len(parsed_response), 0)
+
+
+    def tearDown(self):
+        # After the tests delete all data generated for the tests
+        self.delete_products()
+        self.delete_users()


### PR DESCRIPTION
This change will enable functionality to accept bookings in bulk when more than one bookings is selected in the bookings list. Following updates have been done:
- Adds new api for accepting requests in bulk (/api/caseworker/bookings/bulk/accept)
- Adds a test case to verify the functionality of the bulk assignment for caseworker
- Adds new schema for the json data for booking ids
- Adds new api for accepting requests in bulk (/api/host/pending/bulk/accept)
- Adds a test case to verify the functionality of the bulk assignment for host
