### PR TITLE
570 bug user can make conflicting bookings

### DIFF
--- a/noq_django/backend/models.py
+++ b/noq_django/backend/models.py
@@ -269,28 +269,19 @@ class Booking(models.Model):
                 code="already_booked",
             )
             
-        # Ensure that the user cannot create bookings that overlap with their existing bookings.
+        # Get existing bookings that overlap, excluding the current booking being updated
         existing_bookings = Booking.objects.filter(
         user=self.user,
         start_date__lt=self.end_date,
         end_date__gt=self.start_date,
-        )
+        ).exclude(id=self.id)  # Exclude the current booking
 
-            # Allow saving if:
-            # 1. The existing booking's status is IN_QUEUE and the new status is ACCEPTED
-            # 2. The existing booking's status is PENDING and the new status is DECLINED
+        # If there are overlapping bookings, raise a ValidationError
         if existing_bookings.exists():
-            for existing_booking in existing_bookings:
-                if (existing_booking.status.id == State.IN_QUEUE and self.status.id == State.ACCEPTED) or \
-                (existing_booking.status.id == State.PENDING and self.status.id == State.DECLINED):
-                    # Allow saving the booking
-                    pass
-                else:
-                # If none of the conditions were met, raise a ValidationError
-                    raise ValidationError(
-                        ("You already have a booking that overlaps with these dates."),
-                        code="overlapping_booking",
-                    )
+            raise ValidationError(
+                ("You already have a booking that overlaps with these dates."),
+                code="overlapping_booking",
+            )
 
         # Check if there is free places available for the booking period
         # - Booking count is only valid if booking has status pending

--- a/noq_django/backend/models.py
+++ b/noq_django/backend/models.py
@@ -271,9 +271,9 @@ class Booking(models.Model):
             
         # Get existing bookings that overlap, excluding the current booking being updated
         existing_bookings = Booking.objects.filter(
-        user=self.user,
-        start_date__lt=self.end_date,
-        end_date__gt=self.start_date,
+            user=self.user,
+            start_date__lt=self.end_date,
+            end_date__gt=self.start_date,
         ).exclude(id=self.id)  # Exclude the current booking
 
         # If there are overlapping bookings, raise a ValidationError


### PR DESCRIPTION
The added code ensures that users cannot create overlapping bookings. For example, if a user books a room from 03/11 to 05/11 (Booking 1) and then tries to book another from 04/11 to 07/11 (Booking 2), the system will reject the second booking due to the date conflict.

In addition, it is not allowed to book a booking within an existing booking. For example, if a user books a room from 06/11 to 10/11 and then tries to another from 07/11 to 09/11,  the system will reject the second booking due to the date conflict.

The logic also allows modifying existing bookings without triggering overlap validation errors.