### PR TITLE
569 bug booking that starts in the past can't be approved

### DIFF
--- a/noq_django/rest_api/api/host_api.py
+++ b/noq_django/rest_api/api/host_api.py
@@ -155,7 +155,15 @@ def get_pending_bookings(request, limiter: Optional[
     int] = None):  # Limiter example /pending?limiter=10 for 10 results, empty returns all
     host = Host.objects.get(users=request.user)
     status_list = ['pending', 'accepted', 'advised_against']
-    bookings = Booking.objects.filter(product__host=host, status__description__in=status_list)
+    
+    # Get current date
+    current_date = timezone.now().date()
+
+    bookings = Booking.objects.filter(
+        product__host=host,
+        status__description__in=status_list,
+        start_date__gte=current_date
+    )
 
     if limiter is not None and limiter > 0:
         return bookings[:limiter]

--- a/noq_django/rest_api/api/host_api.py
+++ b/noq_django/rest_api/api/host_api.py
@@ -58,9 +58,16 @@ def get_host_data(request):
 def count_bookings(request):
     host = Host.objects.get(users=request.user)
 
+    # Get current date
+    current_date = timezone.now().date()
+
+    # Count only bookings that have a start date today or in the future
     pending_count = Booking.objects.filter(
         product__host=host,
-        status__description__in=['pending', 'advised_against', 'accepted']).count()
+        status__description__in=['pending', 'advised_against', 'accepted'],
+        start_date__gte=current_date  # Only count bookings with start dates today or in the future
+    ).count()
+    
     arrivals_count = Booking.objects.filter(
         product__host=host,
         start_date=date.today()

--- a/noq_django/rest_api/api/test/test_host_handle_booking_api.py
+++ b/noq_django/rest_api/api/test/test_host_handle_booking_api.py
@@ -40,13 +40,11 @@ class TestHostHandleBookingApi(TestCase):
 
     
     def delete_bookings(self):
-        print("Deleting all bookings...")
         Booking.objects.all().delete()
         
     
     def delete_users(self):
         # Delete the host_user created for the tests
-        print("Deleting all users")
         users = User.objects.all().delete()
 
 
@@ -180,6 +178,9 @@ class TestHostHandleBookingApi(TestCase):
                 status=BookingStatus.objects.get(id=State.PENDING)
             )
         ])
+        # Check the number of pending bookings in the database
+        pending_bookings_count = Booking.objects.filter(status=State.PENDING).count()
+        self.assertEqual(pending_bookings_count, 6)
 
         # Call the API to retrieve pending bookings
         response = self.client.get("/api/host/pending")


### PR DESCRIPTION
The logic prevents the host to see bookings that have past start date. The bookings that has past start date are still in the database, but it is not retrieved from the database. 

In addition, a test was created for this ticket that check that bookings with past start date are not retrieved from the database., hence not sent back to the frontend. 