### PR TITLE
Added activation link via Django email and related tests

### DIFF
--- a/noq_django/rest_api/api/test/test_user_api.py
+++ b/noq_django/rest_api/api/test/test_user_api.py
@@ -7,6 +7,11 @@ from backend.models import (Host, Client, Product, Region, Booking,
                             Available, State, BookingStatus)
 from datetime import datetime, timedelta
 from .test_data import TestData
+from django.utils.http import urlsafe_base64_encode
+from django.utils.encoding import force_bytes
+from django.core import mail
+from django.conf import settings
+from django.contrib.auth.tokens import default_token_generator
 
 class TestUserRegistrationApi(TestCase):
     def setUp(self):
@@ -33,6 +38,12 @@ class TestUserRegistrationApi(TestCase):
 
         # Check response status
         self.assertEqual(response.status_code, 201)
+        body = response.json()
+        self.assertEqual(
+            body["success"],
+            "Användare registrerad! – kolla mejlen för aktivering"
+        )
+        user_id = body["user_id"]
 
         # Check that the User was created
         self.assertTrue(User.objects.filter(email=data["email"]).exists())
@@ -43,6 +54,93 @@ class TestUserRegistrationApi(TestCase):
 
         # Check that the Client record was created
         self.assertTrue(Client.objects.filter(email=data["email"]).exists())
+
+        self.assertEqual(len(mail.outbox), 1)
+        email = mail.outbox[0]
+        self.assertEqual(email.to, [data["email"]])
+        self.assertIn("Välkommen till NoQ – aktivera ditt konto", email.subject)
+
+        uidb64 = urlsafe_base64_encode(force_bytes(user_id))
+        self.assertIn(f"{settings.FRONTEND_URL}{uidb64}/", email.body)
+
+        user = User.objects.get(pk=user_id)
+        self.assertFalse(user.is_active)
+        self.assertTrue(Client.objects.filter(user=user).exists())
+
+#test the email link activation api
+class TestUserActivationApi(TestCase):
+    def setUp(self):
+        # Create one inactive user
+        self.user = User.objects.create_user(
+            email="activate_me@example.com",
+            username="activate_me@example.com",
+            password="SomePass!23",
+            first_name="Activate",
+            last_name="Me",
+            is_active=False,
+        )
+        # Pre‐compute uidb64 and token for all tests
+        self.uidb64 = urlsafe_base64_encode(force_bytes(self.user.pk))
+        self.token = default_token_generator.make_token(self.user)
+        self.url = f"/api/activate/{self.uidb64}/{self.token}/"
+
+    def test_activate_user_success(self):
+        # First POST should activate the user
+        response = self.client.post(self.url, content_type="application/json")
+        self.assertEqual(response.status_code, 200)
+
+        body = response.json()
+        self.assertEqual(body.get("message"), "Konto aktiverat.")
+
+        # Reload from DB and check is_active
+        self.user.refresh_from_db()
+        self.assertTrue(self.user.is_active)
+
+    def test_activate_token_reuse_fails(self):
+        # First activation
+        self.client.post(self.url, content_type="application/json")
+        # Second activation attempt should fail
+        response2 = self.client.post(self.url, content_type="application/json")
+        self.assertEqual(response2.status_code, 400)
+
+        body2 = response2.json()
+        self.assertEqual(
+            body2.get("error"),
+            "Länken är ogiltig eller har gått ut."
+        )
+        # User remains active (since first call worked)
+        self.user.refresh_from_db()
+        self.assertTrue(self.user.is_active)
+
+    def test_activate_with_invalid_token(self):
+        # Use a wrong token
+        bad_url = f"/api/activate/{self.uidb64}/not-a-valid-token/"
+        response = self.client.post(bad_url, content_type="application/json")
+        self.assertEqual(response.status_code, 400)
+
+        body = response.json()
+        self.assertEqual(
+            body.get("error"),
+            "Länken är ogiltig eller har gått ut."
+        )
+        # User still inactive
+        self.user.refresh_from_db()
+        self.assertFalse(self.user.is_active)
+
+    def test_activate_with_bad_uid(self):
+        # Malformed uidb64
+        bad_url = f"/api/activate/bad-uidb64/{self.token}/"
+        response = self.client.post(bad_url, content_type="application/json")
+        self.assertEqual(response.status_code, 400)
+
+        body = response.json()
+        self.assertEqual(
+            body.get("error"),
+            "Ogiltig aktiveringslänk."
+        )
+        # User still inactive
+        self.user.refresh_from_db()
+        self.assertFalse(self.user.is_active)
 
 # New Test Class for Login functionality
 class TestUserApi(TestCase):

--- a/noq_django/rest_api/api/test/test_volunteer_booking.py
+++ b/noq_django/rest_api/api/test/test_volunteer_booking.py
@@ -10,6 +10,11 @@ from backend.models import (
 )
 from django.test import Client as TestClient
 from ..volunteer_api import router  
+from django.utils.http import urlsafe_base64_encode
+from django.utils.encoding import force_bytes
+from django.core import mail
+from django.conf import settings
+from django.contrib.auth.tokens import default_token_generator
 
 
 class TestVolunteerRegistrationApi(TestCase):
@@ -37,6 +42,12 @@ class TestVolunteerRegistrationApi(TestCase):
 
         # Check response status
         self.assertEqual(response.status_code, 201)
+        body = response.json()
+        self.assertEqual(
+            body["success"],
+            "Användare registrerad! – kolla mejlen för aktivering"
+        )
+        user_id = body["user_id"]
 
         # Check that the User was created
         self.assertTrue(User.objects.filter(email=data["email"]).exists())
@@ -47,6 +58,93 @@ class TestVolunteerRegistrationApi(TestCase):
 
         # Check that the Client record was created
         self.assertTrue(Client.objects.filter(email=data["email"]).exists())
+
+        self.assertEqual(len(mail.outbox), 1)
+        email = mail.outbox[0]
+        self.assertEqual(email.to, [data["email"]])
+        self.assertIn("Välkommen till NoQ – aktivera ditt konto", email.subject)
+
+        uidb64 = urlsafe_base64_encode(force_bytes(user_id))
+        self.assertIn(f"{settings.FRONTEND_URL}{uidb64}/", email.body)
+
+        user = User.objects.get(pk=user_id)
+        self.assertFalse(user.is_active)
+        self.assertTrue(Client.objects.filter(user=user).exists())
+
+#test the email link activation api
+class TestUserActivationApi(TestCase):
+    def setUp(self):
+        # Create one inactive user
+        self.user = User.objects.create_user(
+            email="activate_me@example.com",
+            username="activate_me@example.com",
+            password="SomePass!23",
+            first_name="Activate",
+            last_name="Me",
+            is_active=False,
+        )
+        # Pre‐compute uidb64 and token for all tests
+        self.uidb64 = urlsafe_base64_encode(force_bytes(self.user.pk))
+        self.token = default_token_generator.make_token(self.user)
+        self.url = f"/api/activate/{self.uidb64}/{self.token}/"
+
+    def test_activate_user_success(self):
+        # First POST should activate the user
+        response = self.client.post(self.url, content_type="application/json")
+        self.assertEqual(response.status_code, 200)
+
+        body = response.json()
+        self.assertEqual(body.get("message"), "Konto aktiverat.")
+
+        # Reload from DB and check is_active
+        self.user.refresh_from_db()
+        self.assertTrue(self.user.is_active)
+
+    def test_activate_token_reuse_fails(self):
+        # First activation
+        self.client.post(self.url, content_type="application/json")
+        # Second activation attempt should fail
+        response2 = self.client.post(self.url, content_type="application/json")
+        self.assertEqual(response2.status_code, 400)
+
+        body2 = response2.json()
+        self.assertEqual(
+            body2.get("error"),
+            "Länken är ogiltig eller har gått ut."
+        )
+        # User remains active (since first call worked)
+        self.user.refresh_from_db()
+        self.assertTrue(self.user.is_active)
+
+    def test_activate_with_invalid_token(self):
+        # Use a wrong token
+        bad_url = f"/api/activate/{self.uidb64}/not-a-valid-token/"
+        response = self.client.post(bad_url, content_type="application/json")
+        self.assertEqual(response.status_code, 400)
+
+        body = response.json()
+        self.assertEqual(
+            body.get("error"),
+            "Länken är ogiltig eller har gått ut."
+        )
+        # User still inactive
+        self.user.refresh_from_db()
+        self.assertFalse(self.user.is_active)
+
+    def test_activate_with_bad_uid(self):
+        # Malformed uidb64
+        bad_url = f"/api/activate/bad-uidb64/{self.token}/"
+        response = self.client.post(bad_url, content_type="application/json")
+        self.assertEqual(response.status_code, 400)
+
+        body = response.json()
+        self.assertEqual(
+            body.get("error"),
+            "Ogiltig aktiveringslänk."
+        )
+        # User still inactive
+        self.user.refresh_from_db()
+        self.assertFalse(self.user.is_active)
 
 class TestVolunteerApi(TestCase):
     # Constants for test data

--- a/noq_django/rest_api/settings/common.py
+++ b/noq_django/rest_api/settings/common.py
@@ -17,8 +17,7 @@ import environ
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent.parent
 
-env = environ.Env()
-env.read_env(os.path.join(BASE_DIR, ".env"))
+
 
 CORS_ALLOW_HEADERS = [
     'Accept',

--- a/noq_django/rest_api/settings/common.py
+++ b/noq_django/rest_api/settings/common.py
@@ -12,12 +12,9 @@ https://docs.djangoproject.com/en/4.2/ref/settings/
 """
 
 from pathlib import Path
-import environ
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent.parent
-
-
 
 CORS_ALLOW_HEADERS = [
     'Accept',

--- a/noq_django/rest_api/settings/common.py
+++ b/noq_django/rest_api/settings/common.py
@@ -12,9 +12,13 @@ https://docs.djangoproject.com/en/4.2/ref/settings/
 """
 
 from pathlib import Path
+import environ
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent.parent
+
+env = environ.Env()
+env.read_env(os.path.join(BASE_DIR, ".env"))
 
 CORS_ALLOW_HEADERS = [
     'Accept',
@@ -160,10 +164,10 @@ LOGGING = {
 }
 
 # Email configuration
-EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
-EMAIL_HOST = "placeholder" # Add desired smtp server
-EMAIL_PORT = 587 # Placeholder port, potentially change to desired port
-EMAIL_USE_TLS = True # Could use EMAIL_USE_SSL instead
-EMAIL_HOST_USER = os.environ.get("EMAIL_HOST_USER", "name_lastname@example.com")
-EMAIL_HOST_PASSWORD = os.environ.get("EMAIL_HOST_PASSWORD", "password")
+EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
+EMAIL_HOST = 'smtp.gmail.com'
+EMAIL_PORT = 587 
+EMAIL_USE_TLS = True
+EMAIL_HOST_USER = os.environ.get("EMAIL_HOST_USER", None)
+EMAIL_HOST_PASSWORD = os.environ.get("EMAIL_HOST_PASSWORD", None)
 DEFAULT_FROM_EMAIL = EMAIL_HOST_USER

--- a/noq_django/rest_api/settings/dev.py
+++ b/noq_django/rest_api/settings/dev.py
@@ -22,3 +22,5 @@ DATABASES = {
         "NAME": BASE_DIR / "noq.sqlite3",
     }
 }
+
+FRONTEND_URL = os.environ.get("FRONTEND_URL", "http://demo.noqapp.se/login/")

--- a/noq_django/rest_api/settings/prod.py
+++ b/noq_django/rest_api/settings/prod.py
@@ -41,3 +41,5 @@ MEDIA_URL = '/static/media/'
 
 MEDIA_ROOT = '/vol/web/media'
 STATIC_ROOT = '/vol/web/static'
+
+FRONTEND_URL = os.environ.get("FRONTEND_URL", "https://www.noqapp.se/")


### PR DESCRIPTION
Added API for activating a user account and created test for missing email verifications that where missing from last PR. 
Modified existing registration api to include the generation of token and sending link. 

TODO:
Need to test this on our demo server because it works but this needs to be 100% tested since if you cant activate the account you cant login.  