### PR TITLE
Add mock admin user to generate_data for dashboard testing

### DIFF
--- a/noq_django/backend/scripts/generate_data.py
+++ b/noq_django/backend/scripts/generate_data.py
@@ -427,6 +427,25 @@ def add_products(nbr: int = 3):
             type="woman-only",
         )
 
+def add_admin():
+    expected_username = "user.admin@test.nu"
+    user = User.objects.filter(username=expected_username).first()
+
+
+    if user:
+        print("Admin user already exists: ", user.username)
+        return
+
+    user = make_user(
+        group="admin",
+        is_test_user=True,
+        first_name="Jingwen",
+        last_name="Admin"
+    )
+
+    user.save()
+    print("Admin Test user created:", user.username)
+    
 
 def run(*args):
     docs = """
@@ -457,3 +476,4 @@ def run(*args):
 
     add_booking_statuses()
     add_product_bookings(40, 7, v2_arg)
+    add_admin()


### PR DESCRIPTION
This PR adds a mock admin user to the backend test data generation script generate_data.py
to support testing the new Admin Dashboard interface.

### Changes

- Introduced add_admin() helper function that:
    - Checks if a test admin already exists (user.admin@test.nu)
    - If not, creates a Django User with is_admin = True
    - Adds the user to the admin group

- Hooked add_admin() into the run() function so it runs automatically with:
     `python manage.py runscript generate_data`
 
###  Purpose

-  Simplifies frontend development and testing of the admin interface 
-  Avoids the need to manually create an admin user every time mock data is regenerated
