### PR TITLE
Feature/HelpOrgAdmin get detail of activities[#834]

### DIFF
--- a/noq_django/backend/scripts/generate_data_activities.py
+++ b/noq_django/backend/scripts/generate_data_activities.py
@@ -1,8 +1,9 @@
 from faker import Faker
 import random
 from datetime import datetime, timedelta
-from backend.models import Activity
+from backend.models import Activity, VolunteerActivity
 from django.utils import timezone
+from django.contrib.auth.models import User
 
 def add_activities(nbr: int):
     faker = Faker("sv_SE")
@@ -41,6 +42,34 @@ def add_activities(nbr: int):
         activity.save()
         print(f"Skapad: {title} ({start_time} → {end_time})")
 
+def add_volunteer_activities(nbr: int):
+    faker = Faker("sv_SE")
+
+    print("\n---- VOLUNTEER ACTIVITY ANMÄLNINGAR ----")
+
+    users = list(User.objects.filter(groups__name="volunteer"))
+    activities = list(Activity.objects.all())
+
+    created = 0
+    attempts = 0
+
+    while created < nbr and attempts < nbr * 5:
+        attempts += 1
+        activity = random.choice(activities)
+        volunteers = random.sample(users, k = random.randint(1, 2))
+
+        for user in volunteers:
+            
+            if VolunteerActivity.objects.filter(activity=activity, volunteer=user).exists():
+                continue
+
+            VolunteerActivity.objects.create(activity=activity, volunteer=user)
+            print(f"{user.username} anmälde sig till '{activity.title}'")
+            created += 1
+
+            if created >= nbr:
+                break
+
 
 def run(*args):
     docs = """
@@ -53,3 +82,4 @@ def run(*args):
     """
     print(docs)
     add_activities(50)
+    add_volunteer_activities(10)


### PR DESCRIPTION
this PR introduces the HelpOrgAdmin Activities API to the backend. It enables:

- Retrieve the detailed information of a specific activity by its `activity_id`, along with all the volunteers who have signed up for it.

**Implemented Features**

✅ Created new API endpoints:

- GET /api/admin/activities/{activity_id}

✅ Updated mock data generation script:

Create a new function to add 10 records of **volunteer sign-ups to activities (VolunteerActivity)** into the database.

`python manage.py runscript generate_data_activities`

✅ Testing and Verification:

- Successfully ran all tests (64/64 passed) for **backend** and **noq_django**
- API endpoint verified by using Postman.