### PR TITLE
Admin API: Add volunteer list to activities + mock data generation

### DIFF
--- a/noq_django/backend/management/commands/generate_data.py
+++ b/noq_django/backend/management/commands/generate_data.py
@@ -1,0 +1,10 @@
+from django.core.management.base import BaseCommand
+from backend.scripts import generate_data  # ← make sure your script has a run() function
+
+class Command(BaseCommand):
+    help = 'Generate mock data for testing'
+
+    def handle(self, *args, **kwargs):
+        self.stdout.write("Generating mock data...")
+        generate_data.run()
+        self.stdout.write("✅ Mock data generation complete.")

--- a/noq_django/backend/serializers.py
+++ b/noq_django/backend/serializers.py
@@ -11,3 +11,29 @@ class ActivitySerializer(serializers.ModelSerializer):
     def get_is_registered(self, obj) -> bool:
         registered_ids = self.context.get('registered_ids', [])
         return obj.id in registered_ids
+    
+
+class AdminActivitySerializer(serializers.ModelSerializer):
+    signed_up_volunteers = serializers.SerializerMethodField()
+    test = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Activity
+        fields = ['id', 'title', 'description', 'start_time', 'end_time', 'is_approved', 'signed_up_volunteers', 'test']
+
+    def get_signed_up_volunteers(self, obj):
+        volunteer_activities = obj.volunteeractivity_set.all()
+        return [
+            {
+                'id': va.volunteer.id,
+                'first_name': va.volunteer.first_name,
+                'last_name': va.volunteer.last_name,
+                'email': va.volunteer.email,
+                
+            }
+            for va in volunteer_activities
+            ]
+    def get_test(self, obj):
+        return "Danilo was here"
+
+        


### PR DESCRIPTION
## What was added
- Created `admin_activities_api.py` with new endpoints to list and detail activities including signed-up volunteers.
- Updated serializer usage to support the response structure.
- Created `generate_data.py` to allow quick DB population during dev/testing.

## Why
This was needed to unblock the frontend team from displaying volunteer info in the admin dashboard.

## Testing
Tested using Swagger UI. Volunteers are now returned inline with each activity.