### PR TITLE
[Feature] Volunteer profile retrieve, update, and delete (#1053)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,4 +168,4 @@ noq_django/my_project_visualized.png
 .vscode/settings.json
 .vscode/*
 .pytest_cache/*
-
+noq_django/media/

--- a/noq_django/backend/scripts/generate_data.py
+++ b/noq_django/backend/scripts/generate_data.py
@@ -56,7 +56,7 @@ def make_user(group: str, is_test_user: bool, first_name: str, last_name: str) -
         if last_name is None:
             last_name = faker.last_name()
 
-    user = User.objects.create_user(username=email, password=password, first_name=first_name, last_name=last_name)
+    user = User.objects.create_user(username=email, password=password, first_name=first_name, last_name=last_name, email=email)
     group_obj, created = Group.objects.get_or_create(name=group)
     user.groups.add(group_obj)
 
@@ -172,7 +172,7 @@ def add_caseworkers(nbr: int) -> int:
 
 def add_volunteers(nbr: int) -> int:
     from random import choice, sample
-    faker = Faker()
+    faker = Faker("sv_SE")
     print("\n---- VOLUNTEERS ----")
     volunteers_created = 0  
 
@@ -215,8 +215,28 @@ def add_volunteers(nbr: int) -> int:
                 active=True,
                 start_date=timezone.now().date()
             )
+    
+    # Create Client data for the test volunteer if not exist
+    if not Client.objects.filter(user=test_user).exists():
+        region_obj = all_regions[0] if all_regions else None
+        if not region_obj:
+            raise ValueError("No regions available. Please create regions first.")
+        
+        test_client = Client(
+            user=test_user,
+            first_name="Test",
+            last_name="Volunteer",
+            region=region_obj,
+            phone="070" + f"{random.randint(0,9)}-{random.randint(121212,909090)}",
+            email="user.volunteer@test.nu",
+            unokod=f"{random.randint(1000,9999)}",
+            gender="M" if random.randint(0, 1) > 0 else "F",
+            street=faker.street_address(),
+            city=random.choice(get_cities(0)) if all_regions else "Stockholm",
+        )
+        test_client.save(fake_data=datetime.now() - timedelta(days=random.randint(0, 31)))
 
-        volunteers_created += 1
+    volunteers_created += 1
 
     # Calculate remaining volunteers to create
     additional_users_needed = nbr - volunteers_created
@@ -232,6 +252,34 @@ def add_volunteers(nbr: int) -> int:
             first_name=first_name,
             last_name=last_name
         )
+
+        # Create Client data for the volunteer
+        if not Client.objects.filter(user=volunteer_user).exists():
+            regioner = Region.objects.all()
+            ix = random.randint(0, len(regioner) - 1)
+            region = get_region(ix)
+            region_obj = Region.objects.filter(name=region).first()
+            
+            if not region_obj:
+                raise ValueError(f"Region is null! ({region} and {region_obj})")
+            
+            stad = random.choice(get_cities(ix))
+            gender = "M" if random.randint(0, 1) > 0 else "F"
+            last_edit = datetime.now() - timedelta(days=random.randint(0, 31))
+
+            volunteer_client = Client(
+                user=volunteer_user,
+                first_name=first_name,
+                last_name=last_name,
+                region=region_obj,
+                phone="070" + f"{random.randint(0,9)}-{random.randint(121212,909090)}",
+                email=f"{first_name}.{last_name}@hotmejl.se".lower(),
+                unokod=f"{random.randint(1000,9999)}",
+                gender=gender,
+                street=faker.street_address(),
+                city=stad,
+            )
+            volunteer_client.save(fake_data=last_edit)
 
         if not VolunteerProfile.objects.filter(user=volunteer_user).exists():
             profile = VolunteerProfile.objects.create(

--- a/noq_django/rest_api/api/api.py
+++ b/noq_django/rest_api/api/api.py
@@ -43,6 +43,7 @@ api.add_router("/volunteer/activities", "rest_api.api.volunteer_activities_api.r
 api.add_router("/so_admin/", "rest_api.api.admin_api.router")
 api.add_router("/admin/activities", "rest_api.api.admin_activities_api.router")
 api.add_router("/admin/volunteer", "rest_api.api.admin_volunteer_api.router")
+api.add_router("/", "rest_api.api.volunteer_profile_api.router")
 
 
 # temporör testsektion

--- a/noq_django/rest_api/api/api_schemas.py
+++ b/noq_django/rest_api/api/api_schemas.py
@@ -486,3 +486,46 @@ class ActivityListSchema(Schema):
     end_time: datetime
     is_approved: bool
     volunteers: List[SimpleVolunteerSchema]
+
+
+class VolunteerUserProfileSchema(Schema):
+    """
+    Schema for volunteer profile data combining User, Client, and UserProfile information
+    """
+    # From User model
+    first_name: str
+    last_name: str
+    email: str
+
+    # From Client model
+    phone: str
+    gender: Optional[str] = None
+    day_of_birth: Optional[date] = None
+    city: Optional[str] = None
+    postcode: Optional[str] = None
+    address: Optional[str] = None
+
+    # From UserProfile model
+    avatar: Optional[str] = None
+    presentation: Optional[str] = None
+
+
+class VolunteerProfileUpdateSchema(Schema):
+    """
+    Schema for updating volunteer profile data
+    """
+    first_name: Optional[str] = None
+    last_name: Optional[str] = None
+    email: Optional[str] = None
+    phone: Optional[str] = None
+    gender: Optional[str] = None
+    day_of_birth: Optional[date] = None
+    city: Optional[str] = None
+    postcode: Optional[str] = None
+    address: Optional[str] = None
+    presentation: Optional[str] = None
+
+
+class PasswordChangeSchema(Schema):
+    current_password: str
+    new_password: str

--- a/noq_django/rest_api/api/volunteer_profile_api.py
+++ b/noq_django/rest_api/api/volunteer_profile_api.py
@@ -211,7 +211,7 @@ def change_password(request, password_data: PasswordChangeSchema):
         return 400, {"error": "Fel vid ändring av lösenord."}
 
 
-@router.delete("/my_profile", response={204: NoneType, 400: dict, 404: dict}, tags=["Profile"])
+@router.delete("/my_profile", response={204: None, 400: dict, 404: dict}, tags=["Profile"])
 def delete_my_profile(request):
     """
     This does not delete the user from the database but anonymizes all personal information.
@@ -258,7 +258,7 @@ def delete_my_profile(request):
                 user_profile.presentation = "This profile has been anonymized"
                 user_profile.save()
             
-            return 204
+            return 204, None
             
     except Client.DoesNotExist:
         return 404, {"error": "Användarprofilen hittades inte."}

--- a/noq_django/rest_api/api/volunteer_profile_api.py
+++ b/noq_django/rest_api/api/volunteer_profile_api.py
@@ -1,0 +1,266 @@
+from types import NoneType
+
+from ninja import Router
+from ninja.errors import HttpError
+from django.contrib.auth import authenticate
+from django.contrib.auth.models import User
+from django.db import transaction
+from django.core.exceptions import ValidationError
+from django.core.validators import validate_email
+from django.core.files.storage import default_storage
+from django.core.files.base import ContentFile
+from django.conf import settings
+import os
+import uuid
+from datetime import date, datetime
+
+from backend.models import Client, UserProfile
+from backend.auth import group_auth
+from .api_schemas import (
+    VolunteerUserProfileSchema,
+    VolunteerProfileUpdateSchema,
+    PasswordChangeSchema,
+)
+
+router = Router(auth=lambda request: group_auth(request, "volunteer"))
+
+
+@router.get("/my_profile", response={200: VolunteerUserProfileSchema, 404: dict}, tags=["Profile"])
+def get_my_profile(request):
+    """
+    Get current logged-in user's profile information.
+    Creates UserProfile if it doesn't exist.
+    """
+    try:
+        client = Client.objects.get(user=request.user)
+    except Client.DoesNotExist:
+        return 404, {"error": "Användarprofilen hittades inte."}
+    
+    # Get or create UserProfile
+    user_profile, created = UserProfile.objects.get_or_create(
+        user=request.user,
+        defaults={'client': client}
+    )
+
+    # Build avatar URL if avatar exists
+    avatar_url = None
+    if user_profile.avatar:
+        avatar_url = user_profile.avatar.url
+    
+    return VolunteerUserProfileSchema(
+        first_name=request.user.first_name,
+        last_name=request.user.last_name,
+        email=request.user.email,
+        phone=client.phone,
+        gender=client.gender if client.gender else None,
+        day_of_birth=client.day_of_birth if client.day_of_birth else None,
+        city=client.city if client.city else None,
+        postcode=client.postcode if client.postcode else None,
+        address=client.street if client.street else None,
+        avatar=avatar_url,
+        presentation=user_profile.presentation if user_profile.presentation else None,
+    )
+
+
+@router.patch("/my_profile", response={200: VolunteerUserProfileSchema, 400: dict, 404: dict}, tags=["Profile"])
+def update_my_profile(request, profile_data: VolunteerProfileUpdateSchema):
+    """
+    Update current logged-in user's profile information.
+    Allows partial updates of any field.
+    """
+    try:
+        with transaction.atomic():
+            client = Client.objects.get(user=request.user)
+
+            user_profile, created = UserProfile.objects.get_or_create(
+                user=request.user,
+                defaults={'client': client}
+            )
+
+            if profile_data.first_name is not None:
+                request.user.first_name = profile_data.first_name
+            if profile_data.last_name is not None:
+                request.user.last_name = profile_data.last_name
+            if profile_data.email is not None:
+                try:
+                    validate_email(profile_data.email)
+                except ValidationError:
+                    return 400, {"error": "Ogiltigt e-postformat."}
+
+                if User.objects.filter(email=profile_data.email).exclude(id=request.user.id).exists():
+                    return 400, {"error": "E-postadressen är redan tagen av en annan användare."}
+                
+                request.user.email = profile_data.email
+                request.user.username = profile_data.email
+            
+            # Update Client model fields
+            if profile_data.phone is not None:
+                client.phone = profile_data.phone
+            if profile_data.gender is not None:
+                client.gender = profile_data.gender
+            if profile_data.day_of_birth is not None:
+                client.day_of_birth = profile_data.day_of_birth
+            if profile_data.city is not None:
+                client.city = profile_data.city
+            if profile_data.postcode is not None:
+                client.postcode = profile_data.postcode
+            if profile_data.address is not None:
+                client.street = profile_data.address
+
+            # Update UserProfile model fields
+            if profile_data.presentation is not None:
+                user_profile.presentation = profile_data.presentation
+
+            request.user.save()
+            client.save()
+            user_profile.save()
+            
+            # Build avatar URL if avatar exists
+            avatar_url = None
+            if user_profile.avatar:
+                avatar_url = user_profile.avatar.url
+            
+            return VolunteerUserProfileSchema(
+                first_name=request.user.first_name,
+                last_name=request.user.last_name,
+                email=request.user.email,
+                phone=client.phone,
+                gender=client.gender if client.gender else None,
+                day_of_birth=client.day_of_birth,
+                city=client.city if client.city else None,
+                postcode=client.postcode if client.postcode else None,
+                address=client.street if client.street else None,
+                avatar=avatar_url,
+                presentation=user_profile.presentation if user_profile.presentation else None,
+            )
+            
+    except Client.DoesNotExist:
+        return 404, {"error": "Användarprofilen hittades inte."}
+    except Exception as e:
+        return 400, {"error": "Fel uppstod när profilen uppdaterades."}
+
+
+@router.post("/my_profile/avatar", response={200: dict, 400: dict, 404: dict}, tags=["Profile"])
+def upload_avatar(request):
+    try:
+        client = Client.objects.get(user=request.user)
+
+        user_profile, created = UserProfile.objects.get_or_create(
+            user=request.user,
+            defaults={'client': client}
+        )
+
+        if 'avatar' not in request.FILES:
+            return 400, {"error": "Ingen avatarfil tillhandahålls."}
+        
+        avatar_file = request.FILES['avatar']
+
+        allowed_types = ['image/jpeg', 'image/png', 'image/gif', 'image/webp']
+        if avatar_file.content_type not in allowed_types:
+            return 400, {"error": "Ogiltig filtyp. Endast JPEG, PNG, GIF och WebP är tillåtna."}
+
+        max_size = 5 * 1024 * 1024  # 5MB
+        if avatar_file.size > max_size:
+            return 400, {"error": "Filen är för stor. Maximal storlek är 5 MB."}
+
+        file_extension = os.path.splitext(avatar_file.name)[1]
+        unique_filename = f"{uuid.uuid4()}{file_extension}"
+
+        if user_profile.avatar:
+            try:
+                if os.path.isfile(user_profile.avatar.path):
+                    os.remove(user_profile.avatar.path)
+            except (ValueError, OSError):
+                pass
+
+        user_profile.avatar.save(unique_filename, avatar_file, save=True)
+        
+        return 200, {
+            "message": "Avataren har laddats upp",
+            "avatar_url": user_profile.avatar.url
+        }
+        
+    except Client.DoesNotExist:
+        return 404, {"error": "Användarprofilen hittades inte."}
+    except Exception as e:
+        return 400, {"error": "Fel uppstod vid uppladdning av avatar."}
+
+
+@router.post("/my_profile/change_password", response={200: dict, 400: dict}, tags=["Profile"])
+def change_password(request, password_data: PasswordChangeSchema):
+    try:
+        user = authenticate(
+            username=request.user.username,
+            password=password_data.current_password
+        )
+        
+        if not user:
+            return 400, {"error": "Nuvarande lösenord är felaktigt."}
+        
+        # Validate new password
+        if not password_data.new_password or len(password_data.new_password) < 8:
+            return 400, {"error": "Det nya lösenordet måste vara minst 8 tecken långt."}
+        
+        # Set new password
+        request.user.set_password(password_data.new_password)
+        request.user.save()
+        
+        return 200, {"message": "Lösenordet har ändrats."}
+        
+    except Exception as e:
+        return 400, {"error": "Fel vid ändring av lösenord."}
+
+
+@router.delete("/my_profile", response={204: NoneType, 400: dict, 404: dict}, tags=["Profile"])
+def delete_my_profile(request):
+    """
+    This does not delete the user from the database but anonymizes all personal information.
+    """
+    try:
+        with transaction.atomic():
+            client = Client.objects.get(user=request.user)
+
+            try:
+                user_profile = UserProfile.objects.get(user=request.user)
+            except UserProfile.DoesNotExist:
+                user_profile = None
+
+            request.user.first_name = "Anonymized"
+            request.user.last_name = "User"
+            request.user.email = f"anonymized_{request.user.id}@deleted.local"
+            request.user.username = f"anonymized_{request.user.id}"
+            request.user.is_active = False
+            request.user.save()
+
+            client.first_name = "Anonymized"
+            client.last_name = "User"
+            client.phone = "0000000000"
+            client.email = f"anonymized_{request.user.id}@deleted.local"
+            client.gender = ""
+            client.street = ""
+            client.postcode = ""
+            client.city = ""
+            client.country = ""
+            client.day_of_birth = None
+            client.personnr_lastnr = ""
+            client.unokod = f"ANON_{request.user.id}"
+            client.save()
+
+            if user_profile:
+                if user_profile.avatar:
+                    try:
+                        if os.path.isfile(user_profile.avatar.path):
+                            os.remove(user_profile.avatar.path)
+                    except (ValueError, OSError):
+                        pass
+                
+                user_profile.avatar = None
+                user_profile.presentation = "This profile has been anonymized"
+                user_profile.save()
+            
+            return 204
+            
+    except Client.DoesNotExist:
+        return 404, {"error": "Användarprofilen hittades inte."}
+    except Exception as e:
+        return 400, {"error": "Användarutloggning misslyckades."}

--- a/noq_django/rest_api/settings/dev.py
+++ b/noq_django/rest_api/settings/dev.py
@@ -25,3 +25,8 @@ DATABASES = {
 }
 
 FRONTEND_URL = os.environ.get("FRONTEND_URL", "http://demo.noqapp.se/login/")
+
+MEDIA_URL = '/media/'
+MEDIA_ROOT = BASE_DIR / 'media'
+STATIC_URL = '/static/'
+STATIC_ROOT = BASE_DIR / 'static'


### PR DESCRIPTION
1. Add endpoints to handle requests:

- GET /my_profile - retrieve current logged-in volunteer's profile
- PATCH /my_profile - update current logged-in volunteer's profile (allow partial updates of any field)
- POST  /my_profile/avatar - upload avatar
- POST  /my_profile/change_password - allow users to change their own password
- DELETE /my_profile - delete volunteer's info with anonymizing personal information

2. Create additional test data for volunteer which related to `Client` table, add `email` field while creating user.
3. Set up storage path for avatar file in `dev.py` and exclude the storage path in `.gitignore`